### PR TITLE
Implement a workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN rm -f /opt/conda/etc/profile.d/mamba.sh
 RUN echo 'envs_dirs: [ ~/.conda ]' >> /opt/conda/.condarc
 
 # XXX Uncomment this out to reproduce the issue:
-#RUN conda install libmamba=2.3.0
+RUN conda install libmamba=2.3.0
 
 RUN conda create -yn conda-lock conda-lock=3.0.3 \
   && conda clean --all -f -y \

--- a/upsert-kernel-env.py
+++ b/upsert-kernel-env.py
@@ -83,7 +83,7 @@ def dist_name_from_url(url: str) -> str:
 
 
 def dist_names_from_env(env_dir: str) -> set[str]:
-    output = subprocess.check_output(["conda", "list", "--json", "-p", env_dir])
+    output = subprocess.check_output(["mamba", "list", "--json", "-p", env_dir])
     data = json.loads(output)
     return {pkg["dist_name"] for pkg in data}
 


### PR DESCRIPTION
Ok, a quick drill-down shows:
* `conda-lock` is using `mamba` internally
* `mamba list -p ~/.conda/test/` shows conda-forge packages
* `conda list -p ~/.conda/test/` shows some of those conda-forge packages as PyPI packages
I think that there's a discrepancy between how `conda` and `mamba` detect which Python packages come from PyPI.

By switching from `conda` to `mamba` in your upsert script we work around the issue, but this is something we should report upstream.